### PR TITLE
fix: add JSON to languages in extension.toml

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -11,4 +11,4 @@ repository = "https://github.com/kovapatrik/zed-vacuum"
 
 [language_servers.vacuum]
 name = "vacuum"
-languages = ["YAML"]
+languages = ["YAML", "JSON"]


### PR DESCRIPTION
The extension wasn't working for my file written in JSON [as it appears it was intended to](https://github.com/kovapatrik/zed-vacuum/issues/1#issuecomment-2487055064)- looks like a small oversight? At least when I added this locally, it worked for me.

Cheers